### PR TITLE
нормализация хедер футер

### DIFF
--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -1,6 +1,6 @@
 .footer {
   background-color: $main-blue;
-  padding: 42px 0 29px 0;
+  padding: 38px 0 29px 0;
   color: #FFFFFF;
 
   @media (max-width: 768px) {
@@ -10,7 +10,7 @@
   &__top {
     display: flex;
     align-items: center;
-    margin-bottom: 62px;
+    margin-bottom: 50px;
     gap: 120px;
     max-width: 1135px;
 
@@ -80,7 +80,8 @@
 
   &__copyright-link {
     display: block;
-    margin-bottom: 21px;
+    margin-bottom: 13px;
+    line-height: 1.2;
     @media (max-width: 768px) {
       text-align: center;
     }

--- a/src/scss/components/_lang-switcher.scss
+++ b/src/scss/components/_lang-switcher.scss
@@ -3,7 +3,8 @@
   align-items: center;
   color: #004D9F;
   font-size: 14px;
-  margin-right: 5px;
+  margin-right: 16px;
+  gap: 5px;
   @include montserrat-medium;
 
   label {

--- a/src/scss/components/_main-menu.scss
+++ b/src/scss/components/_main-menu.scss
@@ -55,7 +55,7 @@
   }
 
   &__nav {
-    margin-right: 10px;
+    margin-right: 15px;
     transition: all .5s;
 
     ul {


### PR DESCRIPTION

Привести в состояние pixel perfect шапки (header) и подвала (footer) сайта гостиницы. В качестве эталона взять макет "Главная_26.06.2023" с доски Т-4 Гостиница.

Учесть, что мы пока глушим переключатели языка в шапке и то, что в подвале у нас количество ссылок ("Номера" и далее...) может меняться, как в сторону увеличения, так и уменьшения. 